### PR TITLE
Final PR - Deprecate `zerobus-sdk-go` repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Deprecates the [zerobus-sdk-go](https://github.com/databricks/zerobus-sdk-go) repo. The code has been ported to the [zerobus-sdk monorepo](https://github.com/databricks/zerobus-sdk) (Previously the Rust SDK repo).
 
+### Bug Fixes
+Fixed memory safety issue where Go garbage collector could move data while Rust FFI was reading it, causing crashes:        
+  - Implemented proper memory pinning using `runtime.Pinner` in all FFI functions that pass Go slices to Rust
+  - Updated `streamIngestProtoRecords`, `streamIngestProtoRecord`, `streamIngestJSONRecords`, `sdkCreateStream`, and `sdkCreateStreamWithHeadersProvider`
+  - Uses `unsafe.SliceData()` for safe pointer conversion (requires Go 1.20+)
+  - Pins data before passing to Rust, ensuring pointers remain valid during FFI calls
+
 ## Release v0.2.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## Release v0.3.0
+
+Deprecates the [zerobus-sdk-go](https://github.com/databricks/zerobus-sdk-go) repo. The code has been ported to the [zerobus-sdk monorepo](https://github.com/databricks/zerobus-sdk) (Previously the Rust SDK repo).
+
 ## Release v0.2.1
 
 ### Bug Fixes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 # NEXT CHANGELOG
 
-## Release v0.3.0
+## Release v0.4.0
 
 ### New Features and Improvements
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
-# Zerobus Go SDK
+> **This repository has been moved to [databricks/zerobus-sdk](https://github.com/databricks/zerobus-sdk/tree/main/go).** This repo is archived and read-only. All new development, issues, and pull requests should go to the [monorepo](https://github.com/databricks/zerobus-sdk).
+>
+> | SDK | Link |
+> |-----|------|
+> | Rust | [databricks/zerobus-sdk/rust](https://github.com/databricks/zerobus-sdk/tree/main/rust) |
+> | TypeScript | [databricks/zerobus-sdk/typescript](https://github.com/databricks/zerobus-sdk/tree/main/typescript) |
+> | Java | [databricks/zerobus-sdk/java](https://github.com/databricks/zerobus-sdk/tree/main/java) |
+> | Python | [databricks/zerobus-sdk/python](https://github.com/databricks/zerobus-sdk/tree/main/python) |
+> | Go | [databricks/zerobus-sdk/go](https://github.com/databricks/zerobus-sdk/tree/main/go) |
 
-A high-performance Go client for streaming data ingestion into Databricks Delta tables using the Zerobus service.
+# Databricks Zerobus Ingest SDK for Go
 
-## Disclaimer
+[GA](https://docs.databricks.com/release-notes/release-types.html): This SDK is generally available and supported for production use cases. Minor and patch version updates will not contain breaking changes. Major version updates may include breaking changes.
 
-[Public Preview](https://docs.databricks.com/release-notes/release-types.html): This SDK is supported for production use cases and is available to all customers. Databricks is actively working on stabilizing the Zerobus Ingest SDK for Go. Minor version updates may include backwards-incompatible changes.
+We are keen to hear feedback from you on this SDK. Please [file issues](https://github.com/databricks/zerobus-sdk/issues), and we will address them.
 
-We are keen to hear feedback from you on this SDK. Please [file issues](https://github.com/databricks/zerobus-sdk-go/issues), and we will address them.
+The Databricks Zerobus Ingest SDK for Go provides a high-performance client for ingesting data directly into Databricks Delta tables using the Zerobus streaming protocol.
 
 ## Table of Contents
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/databricks/zerobus-sdk/go instead.
 module github.com/databricks/zerobus-sdk-go
 
 go 1.21

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -2,12 +2,23 @@ package tests
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/databricks/zerobus-sdk-go"
 	"google.golang.org/grpc/codes"
 )
+
+func TestMain(m *testing.M) {
+	// Ignore SIGPIPE to prevent the Rust FFI layer from crashing the
+	// process when the mock server writes to a connection that the
+	// client already closed (e.g. after a timeout).
+	signal.Ignore(syscall.SIGPIPE)
+	os.Exit(m.Run())
+}
 
 const testTableName = "test_catalog.test_schema.test_table"
 
@@ -92,9 +103,9 @@ func TestTimeoutedStreamCreation(t *testing.T) {
 		t.Fatal("Expected stream creation to fail due to timeout, but it succeeded")
 	}
 
-	// Give background tasks a moment to realize the timeout occurred
-	// before we stop the mock server in defer
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the mock server's delayed response to complete before
+	// grpcServer.Stop() tears down the connection.
+	time.Sleep(500 * time.Millisecond)
 }
 
 // TestNonRetriableErrorDuringStreamCreation tests that non-retriable errors fail immediately


### PR DESCRIPTION
## What changes are proposed in this pull request?

The Go SDK and all of development for it has been transferred to the [monorepo (databricks/zerobus-sdk/go)](https://github.com/databricks/zerobus-sdk/tree/main/go).

## How is this tested?

N/A
